### PR TITLE
add  pattern**s**  support

### DIFF
--- a/lib/raw.ts
+++ b/lib/raw.ts
@@ -19,6 +19,7 @@ export interface TargetPattern {
 export interface Rule {
     expected: string;
     pattern?: string | string[]; // string | regexp style string or array
+    patterns?: string | string[]; // string | regexp style string or array
     options?: Options;
     specs?: RuleSpec[];
 }

--- a/lib/rule.ts
+++ b/lib/rule.ts
@@ -33,7 +33,7 @@ export default class Rule {
             throw new Error("expected is required");
         }
 
-        this.pattern = this._patternToRegExp(rawRule.pattern);
+        this.pattern = this._patternToRegExp(rawRule.pattern || rawRule.patterns);
         if (this.pattern == null) {
             throw new Error("pattern is required");
         }

--- a/prh.d.ts
+++ b/prh.d.ts
@@ -26,6 +26,7 @@ declare module 'prh/lib/raw' {
     export interface Rule {
         expected: string;
         pattern?: string | string[];
+        patterns?: string | string[];
         options?: Options;
         specs?: RuleSpec[];
     }

--- a/test/ruleSpec.ts
+++ b/test/ruleSpec.ts
@@ -75,6 +75,27 @@ describe("Rule", () => {
             assert(rule.pattern.source === "(?:vv|aa)");
             assert(rule.pattern.global === true);
         });
+        it("filled pattern**s** from string", () => {
+            var rule = new Rule({
+                expected: "vv",
+                patterns: "vv"
+            });
+
+            assert(rule.pattern.source === "vv");
+            assert(rule.pattern.global === true);
+        });
+        it("filled pattern**s** from string[]", () => {
+            var rule = new Rule({
+                expected: "vv",
+                patterns: [
+                    "/vv/",
+                    "aa"
+                ]
+            });
+
+            assert(rule.pattern.source === "(?:vv|aa)");
+            assert(rule.pattern.global === true);
+        });
     });
     describe("#check", () => {
         it("succeed spec", () => {


### PR DESCRIPTION
ルールの指定にpattern**s**を追加でサポートするPull Requestです。
(patternはそのままで、pattern**s**とも書けるようにするだけです)

```yaml
  - expected: Browserify
    patterns:
      - browserify
      - ブラウザリファイ
```
pattern**s**が欲しい理由としては

- 複数の時はpattern**s**としたい(他のは**s**付いてて気になる)
- expectedとpatternsが同じ文字数なので、縦に並んだ時に見やすい！

というのが主な理由です。

メンテのし易さ的にpatternのみにするのもありですが、ご検討お願いします。
