### PR TITLE
C89開始前のtechbooster.ymlにアップデート

### DIFF
--- a/misc/techbooster.yml
+++ b/misc/techbooster.yml
@@ -1,5 +1,10 @@
+# techbooster editor lint!!
+# C89 冬コミ開始前時点で利用している版だよ！
 version: 1
 rules:
+  - expected: TechBooster
+    pattern: てっくぶーすたー
+    prh: 警告メッセージのカスタマイズができるよ！
   # 記号
   # 半角括弧を全角括弧に
   - expected: （$1）
@@ -11,38 +16,55 @@ rules:
         to:   （@<fn>{test}）
       - from: "(ほげ)ほげ)"
         to:   "（ほげ）ほげ)"
+    prh: 半角カッコの代わりに全角カッコを使うこと。文字のバランスが崩れるためです
   # TODO 英単語の前後の空白を殺す
 
   # 開き
   - expected: いえ
     pattern:  言え
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
+  - expected: いう
+    pattern:  言う
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: さまざま
     pattern:  様々
-  # 良い のまま開いてない場合も結構ある
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: よい
     pattern:  良い
+    prh: 良し悪しを評価する表現は"良い"、しなくていい、など評価でない表現は"よい"を使います
   - expected: さらに
     pattern:  更に
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: もつ
     pattern:  持つ
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: とおり
     pattern:  通り
-  - expected: 他の
-    pattern:  ほかの
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります。"どおり"のケースもありえます
   - expected: すでに
     pattern:  既に
-  - expected: 分かる
-    pattern:  わかる
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: すべて
     pattern:  全て
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: たとえば
     pattern:  例えば
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
+  - expected: 他の
+    pattern:  ほかの
+    prh: ひらがなで書かず、漢字で書くと読みやすくなります
+  - expected: 分かる
+    pattern:  わかる
+    prh: ひらがなで書かず、漢字で書くと読みやすくなります
   - expected: $1中
     pattern:  /(その)なか/
+    prh: ひらがなで書かず、漢字で書くと読みやすくなります
   - expected: きれい
     pattern:  綺麗
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: こと
     pattern:  /事(?!情|件|前|後|例)/
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   # 先読み否定戻りができないので悲惨な事に…
   # 時の前後1文字がひらがなの時… とかのほうがよいのでは
   - expected: $1とき
@@ -70,15 +92,19 @@ rules:
         to:   時代
       - from: 時間
         to:   時間
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: でき$1
     pattern:  /出来(る|て|た|ま|上が)/
     specs:
       - from: 出来上がった
         to:   でき上がった
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: したがって
     pattern:  従って
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: $1ように
     pattern:  /(の)様に/
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: 次$1
     pattern:  /以下(の|に)/
     specs:
@@ -88,28 +114,75 @@ rules:
         to:   次に
       - from: 次回
         to:   次回
+    prh: 書籍の場合は、以下ではなく次を利用します（常に下にあるとは限らないため）
   - expected: かかわらず
     pattern:  関わらず
+    pattern:  関らず
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: なる
     pattern:  成る
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: お勧め
     pattern:  おすすめ
+    prh: ひらがなで書かず、漢字で書くと読みやすくなります
   - expected: $1あとで
     pattern:  /(して|した|、)後で/
     specs:
       - from: して後で
         to:   してあとで
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: あらかじめ
     pattern:  予め
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: なぜ
     pattern:  何故
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: ゆえに
     pattern:  故に
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
   - expected: うまく
     pattern:  巧く
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
+  - expected: もっぱら
+    pattern:  専ら
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
+  - expected: はやる
+    pattern:  流行る
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
+  # 通常は、ひとつ。数詞は１つ、漢数字は数えられる固有名詞を指す場合に利用
+  - expected: ひとつ
+    pattern:  一つ
+    prh: 通常は、ひとつ。数詞は１つ、漢数字は数えられる固有名詞を指す場合に利用します
+  - expected: ふたつ
+    pattern:  二つ
+    prh: 通常は、ふたつ。数詞は１つ、漢数字は数えられる固有名詞を指す場合に利用
+  - expected: もっとも
+    pattern:  最も
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
+  - expected: ちょうど
+    pattern:  丁度
+    pattern:  調度
+    prh: 漢字で書かず、ひらがなで書くと読みやすくなります
+  # footnoteの末尾は読点を使わない
+  # タイトル見出しの末尾は読点を使わない
+  # 表、コード見出しの末尾は読点を使わない
+  # 箇条書きの末尾は読点を使わない
+  # 箇条書きの末尾は体言止め、または動詞でとめる、が統一されているか
+  # footnoteの参照は名詞、または末尾にかかっているか（原則、動詞にかからない）
+  # 表、ソースコードへの参照が本体より前に配置されているか。
+  # 文末の参照は（@<img>{id}）。となっているか。@<img>{id}。などはNG
+  # 。（@<list>{manifest_gradle}） などもNG
+  # だいたい、ほとんど、など：曖昧語への注意喚起Lintしたい
+  # listnum記法などあんまり積極的に使いたくない記法を喚起したい
+
+  # 本文中の半角スペースは排除したい
 
   # 横文字
+  - expected: API Level
+    pattern:  API level
+    prh: APIドキュメントでも揺れてますが、Levelで統一してます
   - expected: Web
   - expected: jQuery
   - expected: ライブラリ
     pattern:  ラブライブ # C87でやらかした人がいましたね？
+    prh: C87でざきさんがやらかした思い出


### PR DESCRIPTION
C89にむけてprhをアップデートしました。
 - Lintに文言を表示するようになりました（漢字の開き、閉じについて必要なら指標を提供しています）
 - C88で発見したケースを追加しました