### PR TITLE
fix(WEB+DB_PRESS_r2.yml): 2013年に商号がSBクリエイティブになったそうな

### DIFF
--- a/misc/WEB+DB_PRESS_r2.yml
+++ b/misc/WEB+DB_PRESS_r2.yml
@@ -2979,8 +2979,6 @@ rules:
     pattern:  /\bZIPファイル\b/i
   - expected: オライリー・ジャパン$1
     pattern:  /オライリージャパン([^・])|オライリー([^・])/
-  - expected: ソフトバンク クリエイティブ
-    pattern:  /ソフトバンククリエイティブ/
   - expected: ピアソン・エデュケーション$1
     pattern:  /ピアソンエデュケーション([^・])/
   - expected: を


### PR DESCRIPTION
https://github.com/vvakame/prh/commit/f594222896070eecaa97819b5cd43e5356e8ad68#commitcomment-19468297 @takahashim さん指摘
https://ja.wikipedia.org/wiki/SB%E3%82%AF%E3%83%AA%E3%82%A8%E3%82%A4%E3%83%86%E3%82%A3%E3%83%96
Wikipedia調べ