### PR TITLE
fix(misc): update WEB+DB_PRESS_r2.yml "Debian GNU/Linux"がfixしても校正されてしまうのを修正

### DIFF
--- a/misc/WEB+DB_PRESS_r2.yml
+++ b/misc/WEB+DB_PRESS_r2.yml
@@ -2347,7 +2347,7 @@ rules:
   - expected: DBFlute
     pattern:  /\bDBFlute\b/i
   - expected: Debian GNU/Linux
-    pattern:  /\bDebian\b|Debian\/GNU Linux/
+    pattern:  /\bDebian(?!.* GNU\/Linux)\b|debian|Debian\/GNU Linux/
   - expected: $1DeNA$2
     pattern:  /(?:([^/.])ディー・エヌ・エー)|(?:ディー・エヌ・エー([^/.]))/
   - expected: $1DeNA$2

--- a/misc/WEB+DB_PRESS_r2.yml
+++ b/misc/WEB+DB_PRESS_r2.yml
@@ -2348,6 +2348,9 @@ rules:
     pattern:  /\bDBFlute\b/i
   - expected: Debian GNU/Linux
     pattern:  /\bDebian(?!.* GNU\/Linux)\b|debian|Debian\/GNU Linux/
+    specs:
+      - from: Debian GNU/Linux
+      - to: Debian GNU/Linux
   - expected: $1DeNA$2
     pattern:  /(?:([^/.])ディー・エヌ・エー)|(?:ディー・エヌ・エー([^/.]))/
   - expected: $1DeNA$2

--- a/misc/WEB+DB_PRESS_r2.yml
+++ b/misc/WEB+DB_PRESS_r2.yml
@@ -2350,7 +2350,7 @@ rules:
     pattern:  /\bDebian(?!.* GNU\/Linux)\b|debian|Debian\/GNU Linux/
     specs:
       - from: Debian GNU/Linux
-      - to: Debian GNU/Linux
+        to: Debian GNU/Linux
   - expected: $1DeNA$2
     pattern:  /(?:([^/.])ディー・エヌ・エー)|(?:ディー・エヌ・エー([^/.]))/
   - expected: $1DeNA$2


### PR DESCRIPTION
すばらしいツールのご提供、ありがとうございます。

「Debian GNU/Linux」という単語が、正しいテキストでも校正されてしまっていました。

```
% echo Debian GNU/Linux > test.md
% textlint test.md

  1:1  ✓ error  Debian => Debian GNU/Linux  prh

✖ 1 problem (1 error, 0 warnings)
✓ 1 fixable problem.
```

そこで、否定先読みを使い、校正されないようにしました。
また、「debian」という単語でも校正されるようにもしました。

マージしていただければ幸いです。